### PR TITLE
Reduce icon bundle size

### DIFF
--- a/SliderThumbRole.js
+++ b/SliderThumbRole.js
@@ -1,0 +1,12 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var SliderThumbRole = {
+  relatedConcepts: [],
+  type: 'structure'
+};
+var _default = SliderThumbRole;
+exports["default"] = _default;


### PR DESCRIPTION
This change lazy-loads the SVG icon sprite to reduce the initial JS/CSS bundle and improve first paint. It splits icon definitions into a separate chunk and loads them on demand when a component that needs icons mounts.