### PR TITLE
Accessibility: add aria-label to icon buttons

### DIFF
--- a/ImageMapRole.js
+++ b/ImageMapRole.js
@@ -1,0 +1,20 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var ImageMapRole = {
+  relatedConcepts: [{
+    module: 'HTML',
+    concept: {
+      name: 'img',
+      attributes: [{
+        name: 'usemap'
+      }]
+    }
+  }],
+  type: 'structure'
+};
+var _default = ImageMapRole;
+exports["default"] = _default;


### PR DESCRIPTION
Icon-only buttons lack accessible names for screen readers, causing a poor keyboard and screen reader experience. Add aria-label attributes to the IconButton component, update stories and unit tests, and document the requirement in the component README.